### PR TITLE
Fixed error reading XML files

### DIFF
--- a/src/xmlpngengine.py
+++ b/src/xmlpngengine.py
@@ -356,7 +356,7 @@ def split_spsh(pngpath, xmlpath, udpdatefn):
     try:
         cleaned_xml = ""
         quotepairity = 0
-        with open(xmlpath, 'r') as f:
+        with open(xmlpath, 'r', encoding='utf-8') as f:
             ch = f.read(1)
             while ch and ch != '<':
                 ch = f.read(1)


### PR DESCRIPTION
When reading XML files in environments where the default encoding is not UTF-8, the program terminates with an error.
Therefore, it has been modified to explicitly state the encoding.